### PR TITLE
fix an emergency bug about add button in "Design"

### DIFF
--- a/screens/Design.jsx
+++ b/screens/Design.jsx
@@ -107,7 +107,23 @@ export default function Design() {
 
         </>
       ) : (
-        <Text style={styles.inputTitle}>no puzzle</Text>
+        <>
+          <Text style={styles.inputTitle}>no puzzle</Text>
+          <View style={styles.buttons}>
+              <PressableButton
+                defaultStyle={styles.editNameDefaultStyle}
+                pressedStyle={styles.editNamePressedStyle}
+                onPress={() => {
+                  setModalVisible(true);
+              }}
+              > 
+                <View style={styles.editNameButton}>
+                  <AntDesign name="edit" size={24} color={colors.shadowColor} />
+                  <Text style={styles.inputDisplay}>Add/update</Text>
+                </View>
+              </PressableButton>
+            </View>
+          </>
       )}
 
         </Card>


### PR DESCRIPTION
Emergency bug: When the user has not designed the puzzle or after it's deleted, "Add/Update" is not shown. The user cannot add one then.

Fixed: Added "Add/Update" button back to the "Design" screen.